### PR TITLE
Integrate registration with backend

### DIFF
--- a/src/pages/TelaCadastro/components/FormCadastro.tsx
+++ b/src/pages/TelaCadastro/components/FormCadastro.tsx
@@ -126,7 +126,9 @@ export default function FormCadastro({
       
       sucesso = await handleCadastro(cadastro);
       console.log("Cadastro: ",cadastro);
-      setMostrarModal(true);
+      if (sucesso) {
+        setMostrarModal(true);
+      }
     }
   };
 

--- a/src/pages/TelaCadastro/components/service.ts
+++ b/src/pages/TelaCadastro/components/service.ts
@@ -7,11 +7,30 @@ import { ApiService } from "../../../interceptors/Api/api.intercept";
 export const handleCadastro = async(dados: Cadastro): Promise<boolean> => {
     try {
         const api: AxiosInstance = ApiService.getInstance();
-        await api.post<Cadastro>(`${apiURL}/cadastrar`, dados);
+
+        const formData = new FormData();
+        formData.append('nomeCompleto', dados.nome);
+        formData.append('secretaria', dados.secretaria);
+        formData.append('cpf', dados.cpf);
+        formData.append('departamento', dados.departamento);
+        formData.append('rg', dados.rg);
+        formData.append('matricula', dados.matricula);
+        formData.append('email', dados.email);
+        formData.append('cargo', dados.cargo);
+        formData.append('telefone', dados.telefone);
+        if (dados.foto) {
+            formData.append('foto', dados.foto);
+        }
+        formData.append('senha', dados.senha);
+
+        await api.post(`${apiURL}/usuarios`, formData, {
+            headers: { 'Content-Type': 'multipart/form-data' }
+        });
         return true;
     } catch (error){
         const { showSnackbar } = useSnackbarStore.getState();
         showSnackbar(`Erro ao criar conta: ${error}`, 'error');
         return false;
-    } 
+    }
 }
+


### PR DESCRIPTION
## Summary
- send user registration data to the backend API
- show confirmation modal only when registration succeeds

## Testing
- `npm run lint` *(fails: 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686844ca63f08333a26767fe2217886b