### PR TITLE
Add password visibility toggle in password modal

### DIFF
--- a/src/pages/meus-dados.tsx
+++ b/src/pages/meus-dados.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
   Grid,
   InputAdornment,
+  IconButton,
   Paper,
   TextField,
   Typography,
@@ -17,6 +18,7 @@ import {
   useTheme,
 } from "@mui/material";
 import LockResetIcon from "@mui/icons-material/LockReset";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 import PersonIcon from "@mui/icons-material/Person";
 import BusinessIcon from "@mui/icons-material/Business";
 import ApartmentIcon from "@mui/icons-material/Apartment";
@@ -58,6 +60,9 @@ const PerfilUsuario: React.FC = () => {
   const [senhaAtual, setSenhaAtual] = useState("");
   const [novaSenha, setNovaSenha] = useState("");
   const [confirmaSenha, setConfirmaSenha] = useState("");
+  const [mostrarSenhaAtual, setMostrarSenhaAtual] = useState(false);
+  const [mostrarNovaSenha, setMostrarNovaSenha] = useState(false);
+  const [mostrarConfirmaSenha, setMostrarConfirmaSenha] = useState(false);
 
   const authService = AuthService.getInstance();
   const usuario = authService.getUserStorage();
@@ -121,6 +126,13 @@ const PerfilUsuario: React.FC = () => {
     setNovaSenha("");
     setConfirmaSenha("");
   };
+
+  const toggleMostrarSenhaAtual = () =>
+    setMostrarSenhaAtual((prev) => !prev);
+  const toggleMostrarNovaSenha = () =>
+    setMostrarNovaSenha((prev) => !prev);
+  const toggleMostrarConfirmaSenha = () =>
+    setMostrarConfirmaSenha((prev) => !prev);
 
   const salvarSenha = () => {
     if (novaSenha !== confirmaSenha) {
@@ -428,27 +440,66 @@ const PerfilUsuario: React.FC = () => {
             <Box component="form" noValidate autoComplete="off" sx={{ mt: 1 }}>
               <TextField
                 label="Senha Atual"
-                type="password"
+                type={mostrarSenhaAtual ? "text" : "password"}
                 fullWidth
                 margin="normal"
                 value={senhaAtual}
                 onChange={(e) => setSenhaAtual(e.target.value)}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={toggleMostrarSenhaAtual}
+                        edge="end"
+                        aria-label="Mostrar ou ocultar a senha"
+                      >
+                        {mostrarSenhaAtual ? <Visibility /> : <VisibilityOff />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
               />
               <TextField
                 label="Nova Senha"
-                type="password"
+                type={mostrarNovaSenha ? "text" : "password"}
                 fullWidth
                 margin="normal"
                 value={novaSenha}
                 onChange={(e) => setNovaSenha(e.target.value)}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={toggleMostrarNovaSenha}
+                        edge="end"
+                        aria-label="Mostrar ou ocultar a senha"
+                      >
+                        {mostrarNovaSenha ? <Visibility /> : <VisibilityOff />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
               />
               <TextField
                 label="Confirme a Senha"
-                type="password"
+                type={mostrarConfirmaSenha ? "text" : "password"}
                 fullWidth
                 margin="normal"
                 value={confirmaSenha}
                 onChange={(e) => setConfirmaSenha(e.target.value)}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={toggleMostrarConfirmaSenha}
+                        edge="end"
+                        aria-label="Mostrar ou ocultar a senha"
+                      >
+                        {mostrarConfirmaSenha ? <Visibility /> : <VisibilityOff />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
               />
             </Box>
           </DialogContent>


### PR DESCRIPTION
## Summary
- show/hide password fields in `meus-dados` password dialog

## Testing
- `npm run lint` *(fails: 18 errors)*
- `npm run build` *(fails with TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e6ebb4bc883338bbe5097324297a9